### PR TITLE
Fix dead link in guide metadata

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
   keywords:
     - chicory
     - wasm
-  guide: https://docs.quarkiverse.io/chicory/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  guide: https://docs.quarkiverse.io/quarkus-chicory/dev/ # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
   categories:
     - "miscellaneous"
   status: "preview"


### PR DESCRIPTION
I have, finally, fixed the template so that this error doesn't happen for every extension: https://github.com/quarkusio/quarkus/pull/52235

... but that fix isn't in a release yet.